### PR TITLE
Add hash change updates

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -55,5 +55,18 @@
       or element has not registered
       (<a href="?">remove parameter</a>)
     </only-show>
+
+    <h2>Hash change</h2>
+    <p>
+     <a href="#edit">#edit</a>
+     <a href="#read">#read</a>
+    </p>
+    <only-show when-hash="edit">
+     hash = edit
+    </only-show>
+    <only-show when-hash="read">
+     hash = read
+    </only-show>
+
   </body>
 </html>

--- a/demo.html
+++ b/demo.html
@@ -60,6 +60,7 @@
     <p>
      <a href="#edit">#edit</a>
      <a href="#read">#read</a>
+     <a href="#">#</a>
     </p>
     <only-show when-hash="edit">
      hash = edit

--- a/only-show.js
+++ b/only-show.js
@@ -26,8 +26,10 @@ class OnlyShow extends HTMLElement {
   }
 
   connectedCallback() {
-    // we could listen to window hash changes?
-    // or resize changes for media/container conditions?
+    window.addEventListener('hashchange', ()=> {
+      if(this.hasAttribute('when-hash')) this.showHide();
+    }, false);
+    // watch resize changes for media/container conditions?
   }
 
   disconnectedCallback() {

--- a/only-show.js
+++ b/only-show.js
@@ -25,15 +25,17 @@ class OnlyShow extends HTMLElement {
     this.showHide();
   }
 
+  #hashChanged(){
+    if(this.hasAttribute('when-hash')) this.showHide();
+  }
+
   connectedCallback() {
-    window.addEventListener('hashchange', ()=> {
-      if(this.hasAttribute('when-hash')) this.showHide();
-    }, false);
+    window.addEventListener('hashchange', this.#hashChanged, false);
     // watch resize changes for media/container conditions?
   }
 
   disconnectedCallback() {
-    // remove any external listeners here…
+    window.removeEventListener('hashchange', this.#hashChanged);
   }
 
   get whenParam() { return this.getAttribute('when-param'); };


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&hash)

## Description
For every instance, we add a listener for hash change. We only re-calculate show/hide if the element has the `when-hash` attribute. Alternatively, we could only add a listener if the element has the `when-hash` attribute, but then we would also need to handle if the `when-hash` attribute is added.

## Steps to test/reproduce
Check out the hash change section on the demo page.
