### PR TITLE
Add "has-network" attribute

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -85,5 +85,9 @@
       hash = read
     </show-when>
 
+    <h2>Network status</h2>
+    <p>Use the <code>has-network</code> attribute to show/hide based on network status:</p>
+    <show-when has-network="online">Now we're online</show-when>
+    <show-when has-network="offline">Now we're offline</show-when>
   </body>
 </html>

--- a/show-when.js
+++ b/show-when.js
@@ -29,13 +29,21 @@ class ShowWhen extends HTMLElement {
     if(this.hasAttribute('has-hash')) this.showHide();
   }
 
+  #networkStateChanged() {
+    if (this.hasAttribute('has-network')) this.showHide();
+  }
+
   connectedCallback() {
     window.addEventListener('hashchange', this.#hashChanged.bind(this), false);
+    window.addEventListener('offline', this.#networkStateChanged.bind(this), false);
+    window.addEventListener('online', this.#networkStateChanged.bind(this), false);
     // watch resize changes for media/container conditions?
   }
 
   disconnectedCallback() {
     window.removeEventListener('hashchange', this.#hashChanged.bind(this));
+    window.removeEventListener('offline', this.#networkStateChanged.bind(this));
+    window.removeEventListener('online', this.#networkStateChanged.bind(this));
   }
 
   get hasParam() { return this.getAttribute('has-param'); };
@@ -43,6 +51,7 @@ class ShowWhen extends HTMLElement {
   get hasLang() { return this.getAttribute('has-lang') };
   get hasMedia() { return this.getAttribute('has-media') };
   get hasSupport() { return this.getAttribute('has-support') };
+  get hasNetwork() { return this.getAttribute('has-network') };
   // get whenContainer() { return this.getAttribute('has-container') };
   get matchAny() { return this.hasAttribute('match-any') };
 
@@ -78,12 +87,22 @@ class ShowWhen extends HTMLElement {
     return navigator.languages.includes(this.hasLang);
   }
 
+  #checkNetwork = () => {
+    if (!this.hasNetwork) return;
+    switch (this.hasNetwork) {
+      case 'online': return navigator.onLine;
+      case 'offline': return !navigator.onLine;
+      default: return false;
+    }
+  }
+
   #checkAll = () => [
     this.#checkParam(),
     this.#checkHash(),
     this.#checkMedia(),
     this.#checkSupport(),
     this.#checkLang(),
+    this.#checkNetwork(),
   ];
 
   get matchConditions() {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&has-network)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description
This introduces a `has-network` attribute which allows us to show or hide things based on network status ("online" or "offline")

One thing that might be worth noting: when `has-network` is present but set to an invalid value (ie. something other than `online` or `offline`) the matcher will always return `false`. I wasn't totally sure what the best approach here was: another option would be to return `undefined` and effectively ignore the matcher, but treating other values as false seemed more consistent with how the other conditional attributes behave in cases where a value is invalid, and maybe less likely to lead to confusion where someone, eg. makes a typo.

## Related Issue(s)
An [earlier attempt][1] at this used an `is-offline` attribute. However, on that PR, @mirisuzanne suggested that `has-network="offline | online"` might be a better syntax. I agree, because this has the advantage of putting "online" and "offline" on the same logical footing, making "online" equally targetable for showing / hiding purposes, rather than treating it as a default state.

## Steps to test/reproduce
Use the `has-network` attribute to show/hide based on network status:

```html
<show-when has-network="online">This is visible when we're online</hide-when>
<show-when has-network="offline">...and this is only visible when we're offline</show-when>
```

[1]: https://github.com/oddbird/show-when/pull/7