### PR TITLE
Make Media Queries responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Example using `has-any` option:
 ## ToDo
 
 - Add support for container queries
-- Watch for resize and hashChange and other events
 
 ## Installation
 

--- a/demo.html
+++ b/demo.html
@@ -41,6 +41,24 @@
 
     <hr />
 
+    <h2>Media query</h2>
+    <p>
+      Media query matching is reactive
+      using the media query list's change event,
+      so it will update for both viewport size changes.</p>
+
+    <show-when has-media="(orientation: portrait)" hidden>
+      The viewport is portrait
+    </show-when>
+    <show-when has-media="(orientation: landscape)" hidden>
+      The viewport is landscape
+    </show-when>
+    <hide-when has-media="(prefers-reduced-motion)" hidden>
+      Hidden if user prefers reduced motion
+    </hide-when>
+
+    <hr />
+
     <h2>Fallback to visible</h2>
     <p>
       Without the <code>hidden</code> attribute,

--- a/demo.html
+++ b/demo.html
@@ -45,13 +45,21 @@
     <p>
       Media query matching is reactive
       using the media query list's change event,
-      so it will update for both viewport size changes.</p>
+      so it will react to viewport 
+      and non-viewport media query changes.
+    </p>
 
-    <show-when has-media="(orientation: portrait)" hidden>
-      The viewport is portrait
+    <show-when id="change" has-media="(orientation: portrait)" hidden>
+      The viewport is portrait. Click to change.
     </show-when>
-    <show-when has-media="(orientation: landscape)" hidden>
-      The viewport is landscape
+    <script>
+      change.addEventListener('click', ()=>{
+        change.setAttribute('has-media', '(orientation: landscape)');
+        change.innerText = 'The media query is now `(orientation: landscape)`';
+      })
+    </script>
+    <show-when has-media="print" hidden>
+      Only show in print mode.
     </show-when>
     <hide-when has-media="(prefers-reduced-motion)" hidden>
       Hidden if user prefers reduced motion

--- a/demo.html
+++ b/demo.html
@@ -49,15 +49,12 @@
       and non-viewport media query changes.
     </p>
 
-    <show-when id="change" has-media="(orientation: portrait)" hidden>
-      The viewport is portrait. Click to change.
+    <show-when has-media="(orientation: portrait)" hidden>
+      The viewport is portrait. Resize to see updates.
     </show-when>
-    <script>
-      change.addEventListener('click', ()=>{
-        change.setAttribute('has-media', '(orientation: landscape)');
-        change.innerText = 'The media query is now `(orientation: landscape)`';
-      })
-    </script>
+    <show-when has-media="(orientation: landscape)" hidden>
+      The viewport is landscape. Resize to see updates.
+    </show-when>
     <show-when has-media="print" hidden>
       Only show in print mode.
     </show-when>

--- a/show-when.js
+++ b/show-when.js
@@ -18,6 +18,9 @@ class ShowWhen extends HTMLElement {
 
   #events = new Map();
 
+  /** @type {MediaQueryList?} */
+  #mediaQueryList = null;
+
   constructor() {
     super();
     this.showHide();
@@ -34,7 +37,7 @@ class ShowWhen extends HTMLElement {
     const neededEvents = new Set();
     if (this.hasAttribute('has-hash')) neededEvents.add('hash');
     if (this.hasAttribute('has-network')) neededEvents.add('network');
-    if (this.hasAttribute('has-media')) neededEvents.add(`media`);
+    if (this.hasAttribute('has-media')) neededEvents.add(`media_${this.hasMedia}`);
 
     neededEvents.forEach(event => {
       if (!existingEvents.has(event)){
@@ -51,17 +54,17 @@ class ShowWhen extends HTMLElement {
   #addEvent(type){
     const controller = new AbortController();
     const options = {signal: controller.signal};
-    switch (type) {
-      case 'hash':
+    switch (true) {
+      case type === 'hash':
         window.addEventListener('hashchange', this.showHide.bind(this), options);
         break;
-      case 'network':
+      case type === 'network':
         window.addEventListener('offline', this.showHide.bind(this), options);
         window.addEventListener('online', this.showHide.bind(this), options);
         break;
-      case 'media':
-        const mql = window.matchMedia(this.hasMedia);
-        mql.addEventListener('change', this.showHide.bind(this), options);
+      case type.startsWith('media'):
+        this.#ensureMediaQuery();
+        this.#mediaQueryList?.addEventListener('change', this.showHide.bind(this), options);
         break;
     
       default:
@@ -108,9 +111,17 @@ class ShowWhen extends HTMLElement {
     return location.hash === `#${this.hasHash}`;
   }
 
+  // Makes sure that the active media query list matches hasMedia value
+  #ensureMediaQuery = () => {
+    if (!this.hasMedia) return;
+    if(this.#mediaQueryList?.media === this.hasMedia) return;
+    this.#mediaQueryList = window.matchMedia?.(this.hasMedia);
+  }
+
   #checkMedia = () => {
     if (!this.hasMedia) return;
-    return !!window.matchMedia?.(this.hasMedia).matches;
+    this.#ensureMediaQuery();
+    return !!this.#mediaQueryList?.matches;
   }
 
   #checkSupport = () => {

--- a/show-when.js
+++ b/show-when.js
@@ -34,6 +34,7 @@ class ShowWhen extends HTMLElement {
     const neededEvents = new Set();
     if (this.hasAttribute('has-hash')) neededEvents.add('hash');
     if (this.hasAttribute('has-network')) neededEvents.add('network');
+    if (this.hasAttribute('has-media')) neededEvents.add(`media`);
 
     neededEvents.forEach(event => {
       if (!existingEvents.has(event)){
@@ -57,6 +58,11 @@ class ShowWhen extends HTMLElement {
       case 'network':
         window.addEventListener('offline', this.showHide.bind(this), options);
         window.addEventListener('online', this.showHide.bind(this), options);
+        break;
+      case 'media':
+        const mql = window.matchMedia(this.hasMedia);
+        mql.addEventListener('change', this.showHide.bind(this), options);
+        break;
     
       default:
         break;


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&fixyou)

## Description
Adds events for when media query match changes, and also handles when the `has-media` value itself is changed.

## Related Issue(s)
#5 


## Steps to test/reproduce
1. Use your dev tools to emulate `prefers-reduced-motion`
2. Make your viewport portrait, see a box appear. Click on it, and the media query has changed to landscape. Make your viewport landscape to see it again.
3. Print, and see that a new print-only box appears


