### PR TITLE
Allow dynamic element creation

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -112,5 +112,20 @@
     <p>Use the <code>has-network</code> attribute to show/hide based on network status:</p>
     <show-when has-network="online">Now we're online</show-when>
     <show-when has-network="offline">Now we're offline</show-when>
+
+    <h2>Dynamic element creation</h2>
+    <button id="createElement" type="button">Create element</button>
+    <div id="dynamic"></div>
+    <script>
+      const createElement = document.getElementById('createElement');
+      createElement.addEventListener('click', () => {
+        const dynamic = document.getElementById('dynamic');
+        const el = document.createElement('show-when');
+        el.hidden = true;
+        el.setAttribute('has-support', 'display:block');
+        el.innerText = 'Supports `display:block`. Dynamically added, hidden by default but should be visible immediately.'
+        dynamic.appendChild(el);
+      });
+    </script>
   </body>
 </html>

--- a/show-when.js
+++ b/show-when.js
@@ -23,12 +23,22 @@ class ShowWhen extends HTMLElement {
 
   constructor() {
     super();
-    this.showHide();
   }
 
   attributeChangedCallback() {
     this.showHide();
     this.#checkEvents();
+  }
+
+  connectedCallback() {
+    this.showHide();
+    this.#checkEvents();
+  }
+
+  disconnectedCallback() {
+    this.#events.forEach((controller)=>{
+      controller.abort();
+    });
   }
 
   #checkEvents(){
@@ -72,17 +82,6 @@ class ShowWhen extends HTMLElement {
     }
     this.#events.set(type, controller);
     return controller;
-  }
-
-  connectedCallback() {
-    this.#checkEvents();
-    // watch resize changes for media/container conditions?
-  }
-
-  disconnectedCallback() {
-    this.#events.forEach((controller)=>{
-      controller.abort();
-    });
   }
 
   get hasParam() { return this.getAttribute('has-param'); };


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&dynamo)

## Description
Before, a dynamically created element would have show/hide evaluated on construction. This meant that if a element was set to default to `hidden`, it would first evaluate conditions, and then set the hidden attribute.

## Steps to test/reproduce
To see the problem- in the [demo](https://oddbird.github.io/show-when/demo.html), paste the following into the dev tools console and run-

```
const el = document.createElement('show-when');
el.setAttribute('has-support', 'display:block');
el.innerText = 'Supports `display:block`. Dynamically added, hidden by default but should be visible immediately.'
el.hidden = true;
document.body.appendChild(el);
```

The element will be `hidden` due to the hidden attribute being set after evaluation. If you run the same code (or click the Create element button) on this branch, the element will be visible.

This follows the recommendations from the spec about what happens in the constructor- https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance
